### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ryclarke/batch-tool/security/code-scanning/1](https://github.com/ryclarke/batch-tool/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions. Since the workflow only checks out code, builds, and runs tests, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the root level of the workflow (just after the `name:` and before `on:`), setting `contents: read`. This will apply the restriction to all jobs in the workflow unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
