### PR TITLE
Process improvments

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,5 +31,19 @@ jobs:
     - name: Build
       run: make build
 
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.23'
+
+    - name: Install Gotestsum
+      run: go install gotest.tools/gotestsum@latest
+
     - name: Test
-      run: make test
+      run: make cover

--- a/Makefile
+++ b/Makefile
@@ -1,45 +1,54 @@
 SOURCES = go.mod go.sum $(shell find * -type f -name "*.go")
 
-.PHONY: help install build .pretest test cover release clean veryclean check-goreleaser
-
-check-goreleaser:
-	@which goreleaser > /dev/null || (echo "Error: goreleaser is not installed. Please install it first: https://goreleaser.com/install/" && exit 1)
+.PHONY: help deps install build release test cover vendor clean veryclean .gotestsum .goreleaser
 
 help:
 	@echo "Makefile targets:"
 	@echo "  help         Show this help message"
+	@echo "  deps         Install required tools (gotestsum, goreleaser)"
 	@echo "  install      Install batch-tool to ${GOPATH}/bin"
 	@echo "  build        Build the executable for the current OS and architecture using GoReleaser"
 	@echo "  release      Create release packages for all platforms using GoReleaser"
 	@echo "  test         Run tests"
-	@echo "  cover        Run tests with coverage"
+	@echo "  cover        Run tests with coverage report"
 	@echo "  clean        Remove build artifacts"
 	@echo "  veryclean    Remove all generated files including vendor dependencies"
+
+deps:
+	@echo "Installing required tools..."
+	go install gotest.tools/gotestsum@latest
+	go install github.com/goreleaser/goreleaser/v2@latest
 
 install: ${GOPATH}/bin/batch-tool
 ${GOPATH}/bin/batch-tool: $(SOURCES)
 	@echo "Installing batch-tool to ${GOPATH}/bin"
-	@go install
+	@go install -ldflags "-s -w -X github.com/ryclarke/batch-tool/config.Version=$(shell git tag | tail -n1)"
 
-build: check-goreleaser
+build: .goreleaser
 	@echo "Building for current platform..."
 	goreleaser build --snapshot --clean --single-target
 
-release: check-goreleaser
+release: .goreleaser
 	@echo "Creating release packages..."
 	goreleaser release --clean
 
-.pretest:
-	go mod tidy && go mod vendor
+test: vendor .gotestsum
+	@gotestsum ./...
 
-test: .pretest
-	go test ./... -v
+cover: vendor .gotestsum
+	@gotestsum -- -coverprofile=coverage.out ./...
 
-cover: .pretest
-	go test ./... -cover -v
+vendor:
+	@go mod tidy && go mod vendor
 
 clean:
 	@rm -rf dist/
 
 veryclean: clean
 	@rm -rf vendor/
+
+.gotestsum:
+	@which gotestsum > /dev/null || (echo "Error: gotestsum is not installed. Please install it first: https://github.com/gotestyourself/gotestsum#install" && exit 1)
+
+.goreleaser:
+	@which goreleaser > /dev/null || (echo "Error: goreleaser is not installed. Please install it first: https://goreleaser.com/install/" && exit 1)

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -147,6 +147,10 @@ func saveCatalogCache() error {
 		return err
 	}
 
+	if err := os.MkdirAll(filepath.Dir(catalogCachePath()), 0755); err != nil {
+		return err
+	}
+
 	return os.WriteFile(catalogCachePath(), data, 0644)
 }
 


### PR DESCRIPTION
Add `make deps` to install build dependencies
Use gotestsum for cleaner test/cover output
Distinguish between build and test in GH Workflow
(fix) Create directory structure for repo catalog if missing
(fix) `make install` now correctly detects the latest release version