### PR TITLE
Respect Github API rate limiting

### DIFF
--- a/call/do.go
+++ b/call/do.go
@@ -79,5 +79,12 @@ func processArguments(args []string) []string {
 		sort.Strings(repos)
 	}
 
+	// Determine appropriate write backoff based on number of repositories to be processed (GitHub only)
+	if viper.GetString(config.GitProvider) == "github" && len(repos) < viper.GetInt(config.GithubHourlyWriteLimit)/2 {
+		viper.Set(config.WriteBackoff, viper.GetString(config.GithubBackoffSmall))
+	} else {
+		viper.Set(config.WriteBackoff, viper.GetString(config.GithubBackoffLarge))
+	}
+
 	return repos
 }

--- a/config/configurations.go
+++ b/config/configurations.go
@@ -51,6 +51,11 @@ const (
 
 	ChannelBuffer  = "channels.buffer-size"
 	MaxConcurrency = "channels.max-concurrency"
+	WriteBackoff   = "channels.write-backoff"
+
+	GithubHourlyWriteLimit = "github.hourly-write-limit"
+	GithubBackoffSmall     = "github.write-backoff-small"
+	GithubBackoffLarge     = "github.write-backoff-large"
 )
 
 // Init reads in config file and ENV variables if set.
@@ -109,6 +114,14 @@ func initialize() {
 
 	viper.SetDefault(ChannelBuffer, 100)
 	viper.SetDefault(MaxConcurrency, runtime.NumCPU()) // Default to number of logical CPUs
+	viper.SetDefault(WriteBackoff, "1s")
+
+	// GitHub's secondary rate limit is 80 requests per minute, or 500 requests per hour
+	// 1s keeps us safely under the per-minute limit
+	// 8s keeps us safely under the per-hour limit when working with many repositories
+	viper.SetDefault(GithubHourlyWriteLimit, 500)
+	viper.SetDefault(GithubBackoffSmall, "1s")
+	viper.SetDefault(GithubBackoffLarge, "8s")
 
 	// default reviewers in the form `repo: [reviewers...]`
 	viper.SetDefault(DefaultReviewers, map[string][]string{})

--- a/scm/github/pr.go
+++ b/scm/github/pr.go
@@ -5,15 +5,16 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/v74/github"
+	"github.com/spf13/viper"
+
 	"github.com/ryclarke/batch-tool/catalog"
 	"github.com/ryclarke/batch-tool/config"
 	"github.com/ryclarke/batch-tool/scm"
-	"github.com/spf13/viper"
 )
 
 // GetPullRequest retrieves a pull request by repository name and source branch.
 func (g *Github) GetPullRequest(repo, branch string) (*scm.PullRequest, error) {
-	resp, err := g.getPullRequest(repo, branch)
+	resp, err := g.getPullRequest(context.TODO(), repo, branch)
 	if err != nil {
 		return nil, err
 	}
@@ -23,6 +24,11 @@ func (g *Github) GetPullRequest(repo, branch string) (*scm.PullRequest, error) {
 
 // OpenPullRequest opens a new pull request in the specified repository.
 func (g *Github) OpenPullRequest(repo, branch, title, description string, reviewers []string) (*scm.PullRequest, error) {
+	// reads are less restrictive than a failed write, so check for existing PR first
+	if _, err := g.getPullRequest(context.TODO(), repo, branch); err == nil {
+		return nil, fmt.Errorf("a pull request already exists for branch %s in repository %s", branch, repo)
+	}
+
 	// check default branch for the current repo, or use the fallback config
 	defaultBranch := catalog.Catalog[repo].DefaultBranch
 	if defaultBranch == "" {
@@ -34,21 +40,22 @@ func (g *Github) OpenPullRequest(repo, branch, title, description string, review
 		title = branch
 	}
 
-	resp, _, err := g.client.PullRequests.Create(context.TODO(), g.project, repo, &github.NewPullRequest{
+	req := &github.NewPullRequest{
 		Title: github.Ptr(title),
 		Body:  github.Ptr(description),
 		Head:  github.Ptr(branch),
 		Base:  github.Ptr(defaultBranch),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to open pull request: %w", err)
 	}
 
-	resp, _, err = g.client.PullRequests.RequestReviewers(context.TODO(), g.project, repo, resp.GetNumber(), github.ReviewersRequest{
-		Reviewers: reviewers,
-	})
+	resp, err := g.openPullRequest(context.TODO(), repo, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to request reviewers: %w", err)
+		return nil, err
+	}
+
+	if len(reviewers) > 0 {
+		if resp, err = g.requestReviewers(context.TODO(), repo, resp.GetNumber(), github.ReviewersRequest{Reviewers: reviewers}); err != nil {
+			return nil, err
+		}
 	}
 
 	return parsePR(resp), nil
@@ -56,27 +63,25 @@ func (g *Github) OpenPullRequest(repo, branch, title, description string, review
 
 // UpdatePullRequest updates an existing pull request.
 func (g *Github) UpdatePullRequest(repo, branch, title, description string, reviewers []string, appendReviewers bool) (*scm.PullRequest, error) {
-	pr, err := g.getPullRequest(repo, branch)
+	pr, err := g.getPullRequest(context.TODO(), repo, branch)
 	if err != nil {
 		return nil, err
 	}
 
 	if title != "" || description != "" {
-		pr, _, err = g.client.PullRequests.Edit(context.TODO(), g.project, repo, pr.GetNumber(), &github.PullRequest{
+		req := &github.PullRequest{
 			Title: &title,
 			Body:  &description,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to update pull request: %w", err)
+		}
+
+		if pr, err = g.editPullRequest(context.TODO(), repo, pr.GetNumber(), req); err != nil {
+			return nil, err
 		}
 	}
 
 	if len(reviewers) > 0 {
-		pr, _, err = g.client.PullRequests.RequestReviewers(context.TODO(), g.project, repo, pr.GetNumber(), github.ReviewersRequest{
-			Reviewers: reviewers,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to request reviewers: %w", err)
+		if pr, err = g.requestReviewers(context.TODO(), repo, pr.GetNumber(), github.ReviewersRequest{Reviewers: reviewers}); err != nil {
+			return nil, err
 		}
 	}
 
@@ -84,7 +89,7 @@ func (g *Github) UpdatePullRequest(repo, branch, title, description string, revi
 }
 
 func (g *Github) MergePullRequest(repo, branch string) (*scm.PullRequest, error) {
-	pr, err := g.getPullRequest(repo, branch)
+	pr, err := g.getPullRequest(context.TODO(), repo, branch)
 	if err != nil {
 		return nil, err
 	}
@@ -93,22 +98,37 @@ func (g *Github) MergePullRequest(repo, branch string) (*scm.PullRequest, error)
 		return nil, fmt.Errorf("pull request %s [%d] for %s is not mergeable: %s", branch, pr.GetNumber(), repo, pr.GetMergeableState())
 	}
 
-	_, _, err = g.client.PullRequests.Merge(context.TODO(), g.project, repo, pr.GetNumber(), "", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to merge pull request: %w", err)
+	if err = g.mergePullRequest(context.TODO(), repo, pr.GetNumber()); err != nil {
+		return nil, err
 	}
 
-	// Implementation goes here
 	return parsePR(pr), nil
 }
 
-func (g *Github) getPullRequest(repo, branch string) (*github.PullRequest, error) {
-	resp, _, err := g.client.PullRequests.List(context.TODO(), g.project, repo, &github.PullRequestListOptions{
+func (g *Github) getPullRequest(ctx context.Context, repo, branch string) (*github.PullRequest, error) {
+	// acquire read lock (and release it when done)
+	defer readLock()()
+
+	opts := &github.PullRequestListOptions{
 		State: "open",
 		Head:  branch,
-	})
+	}
+
+	resp, _, err := g.client.PullRequests.List(ctx, g.project, repo, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pull requests: %w", err)
+		if _, ok := err.(*github.RateLimitError); !ok {
+			return nil, fmt.Errorf("failed to get pull request: %w", err)
+		} else {
+			if rateErr := g.waitForRateLimit(ctx, true); rateErr != nil {
+				return nil, fmt.Errorf("failed to get pull request: %w: %w", rateErr, err)
+			}
+
+			// retry the request after waiting for the rate limit to reset
+			resp, _, err = g.client.PullRequests.List(ctx, g.project, repo, opts)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get pull request after retry: %w", err)
+			}
+		}
 	}
 
 	if len(resp) == 0 {
@@ -116,6 +136,99 @@ func (g *Github) getPullRequest(repo, branch string) (*github.PullRequest, error
 	}
 
 	return resp[0], nil
+}
+
+func (g *Github) openPullRequest(ctx context.Context, repo string, req *github.NewPullRequest) (*github.PullRequest, error) {
+	// acquire write lock (and release it when done)
+	defer writeLock()()
+
+	resp, _, err := g.client.PullRequests.Create(ctx, g.project, repo, req)
+	if err != nil {
+		if _, ok := err.(*github.RateLimitError); !ok {
+			return nil, fmt.Errorf("failed to open pull request: %w", err)
+		} else {
+			if rateErr := g.waitForRateLimit(ctx, false); rateErr != nil {
+				return nil, fmt.Errorf("failed to open pull request: %w: %w", rateErr, err)
+			}
+
+			// retry the request after waiting for the rate limit to reset
+			resp, _, err = g.client.PullRequests.Create(ctx, g.project, repo, req)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open pull request after retry: %w", err)
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+func (g *Github) editPullRequest(ctx context.Context, repo string, prNumber int, req *github.PullRequest) (*github.PullRequest, error) {
+	// acquire write lock (and release it when done)
+	defer writeLock()()
+
+	pr, _, err := g.client.PullRequests.Edit(ctx, g.project, repo, prNumber, req)
+	if err != nil {
+		if _, ok := err.(*github.RateLimitError); !ok {
+			return nil, fmt.Errorf("failed to update pull request: %w", err)
+		} else {
+			if rateErr := g.waitForRateLimit(ctx, false); rateErr != nil {
+				return nil, fmt.Errorf("failed to update pull request: %w: %w", rateErr, err)
+			}
+
+			// retry the request after waiting for the rate limit to reset
+			if pr, _, err = g.client.PullRequests.Edit(ctx, g.project, repo, prNumber, req); err != nil {
+				return nil, fmt.Errorf("failed to update pull request after retry: %w", err)
+			}
+		}
+	}
+
+	return pr, nil
+}
+
+func (g *Github) requestReviewers(ctx context.Context, repo string, prNumber int, req github.ReviewersRequest) (*github.PullRequest, error) {
+	// acquire write lock (and release it when done)
+	defer writeLock()()
+
+	resp, _, err := g.client.PullRequests.RequestReviewers(ctx, g.project, repo, prNumber, req)
+	if err != nil {
+		if _, ok := err.(*github.RateLimitError); !ok {
+			return nil, fmt.Errorf("failed to request reviewers: %w", err)
+		} else {
+			if rateErr := g.waitForRateLimit(ctx, false); rateErr != nil {
+				return nil, fmt.Errorf("failed to request reviewers: %w: %w", rateErr, err)
+			}
+
+			// retry the request after waiting for the rate limit to reset
+			if resp, _, err = g.client.PullRequests.RequestReviewers(ctx, g.project, repo, prNumber, req); err != nil {
+				return nil, fmt.Errorf("failed to request reviewers after retry: %w", err)
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+func (g *Github) mergePullRequest(ctx context.Context, repo string, prNumber int) error {
+	// acquire write lock (and release it when done)
+	defer writeLock()()
+
+	_, _, err := g.client.PullRequests.Merge(ctx, g.project, repo, prNumber, "", nil)
+	if err != nil {
+		if _, ok := err.(*github.RateLimitError); !ok {
+			return fmt.Errorf("failed to merge pull request: %w", err)
+		} else {
+			if rateErr := g.waitForRateLimit(ctx, false); rateErr != nil {
+				return fmt.Errorf("failed to merge pull request: %w: %w", rateErr, err)
+			}
+
+			// retry the request after waiting for the rate limit to reset
+			if _, _, err = g.client.PullRequests.Merge(ctx, g.project, repo, prNumber, "", nil); err != nil {
+				return fmt.Errorf("failed to merge pull request after retry: %w", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func parsePR(resp *github.PullRequest) *scm.PullRequest {

--- a/scm/github/provider.go
+++ b/scm/github/provider.go
@@ -1,14 +1,28 @@
 package github
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/google/go-github/v74/github"
 	"github.com/spf13/viper"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/ryclarke/batch-tool/config"
 	"github.com/ryclarke/batch-tool/scm"
 )
+
+const (
+	// weights designed to avoid secondary rate limiting for creative requests
+	// https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+	writeWeight = 10
+	readWeight  = 1
+)
+
+var sem = semaphore.NewWeighted(writeWeight)
 
 var _ scm.Provider = new(Github)
 
@@ -28,4 +42,50 @@ func New(project string) scm.Provider {
 type Github struct {
 	client  *github.Client
 	project string
+}
+
+func (g *Github) waitForRateLimit(ctx context.Context, search bool) error {
+	rate, err := g.checkRateLimit(ctx, search)
+	if err != nil {
+		return err
+	}
+
+	// inform the user of the wait time to expect
+	fmt.Fprintf(os.Stderr, "... rate limit exceeded, waiting until %s ...\n", rate.Reset.GetTime().Format(time.RFC1123))
+
+	// wait until rate limit resets, plus a buffer
+	time.Sleep(time.Until(*rate.Reset.GetTime()) + 2*time.Second)
+
+	return nil
+}
+
+func (g *Github) checkRateLimit(ctx context.Context, search bool) (*github.Rate, error) {
+	limits, _, err := g.client.RateLimit.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check rate limits: %w", err)
+	}
+
+	if search {
+		return limits.Search, nil
+	}
+
+	return limits.Core, nil
+}
+
+func readLock() (done func()) {
+	sem.Acquire(context.Background(), readWeight)
+
+	return func() {
+		sem.Release(readWeight)
+	}
+}
+
+func writeLock() (done func()) {
+	sem.Acquire(context.Background(), writeWeight)
+
+	return func() {
+		// delay release to avoid rate limiting
+		time.Sleep(viper.GetDuration(config.WriteBackoff))
+		sem.Release(writeWeight)
+	}
 }


### PR DESCRIPTION
Upon exceeding a primary rate limit, the request will now wait and automatically retry when the rate limit resets.

Also includes mitigation against secondary rate limiting for creative operations, like opening or editing pull requests, by limiting concurrency in the API integration with Github. This is independent of (and not controllable by) the `--max-concurrency` flag as it represents an external constraint beyond our control.

Closes #26 